### PR TITLE
fix fetch reliability, memory leaks, and click-seek bug

### DIFF
--- a/src/AmLyrics.ts
+++ b/src/AmLyrics.ts
@@ -4,6 +4,24 @@ import { GoogleService } from './GoogleService.js';
 
 const VERSION = '1.1.7';
 const INSTRUMENTAL_THRESHOLD_MS = 7000; // Show dots for gaps >= 7s
+const FETCH_TIMEOUT_MS = 8000; // Timeout for all lyrics fetch requests
+
+/**
+ * Fetch with an automatic timeout via AbortSignal.
+ * Rejects if the request takes longer than `timeoutMs`.
+ */
+function fetchWithTimeout(
+  url: string,
+  options: Parameters<typeof fetch>[1] = {},
+  timeoutMs = FETCH_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  return fetch(url, { ...options, signal: controller.signal }).finally(() =>
+    clearTimeout(timeoutId),
+  );
+}
 
 const KPOE_SERVERS = [
   'https://lyricsplus.binimum.org',
@@ -1491,10 +1509,18 @@ export class AmLyrics extends LitElement {
 
   private scrollAnimationTimeout?: ReturnType<typeof setTimeout>;
 
+  // AbortController for cancelling in-flight lyrics fetches
+  private fetchAbortController?: AbortController;
+
   // Syllable animation tracking
   private lastActiveIndex = 0;
 
   private visibleLineIds: Set<string> = new Set();
+
+  // Bound handler references for proper event listener removal
+  private _boundHandleUserScroll = this.handleUserScroll.bind(this);
+
+  private _boundAnimateProgress = this.animateProgress.bind(this);
 
   connectedCallback() {
     super.connectedCallback();
@@ -1505,13 +1531,46 @@ export class AmLyrics extends LitElement {
     super.disconnectedCallback();
     if (this.animationFrameId) {
       cancelAnimationFrame(this.animationFrameId);
+      this.animationFrameId = undefined;
     }
     if (this.userScrollTimeoutId) {
       clearTimeout(this.userScrollTimeoutId);
+      this.userScrollTimeoutId = undefined;
+    }
+    if (this.clickSeekTimeout) {
+      clearTimeout(this.clickSeekTimeout);
+      this.clickSeekTimeout = undefined;
+    }
+    if (this.scrollUnlockTimeout) {
+      clearTimeout(this.scrollUnlockTimeout);
+      this.scrollUnlockTimeout = undefined;
+    }
+    if (this.scrollAnimationTimeout) {
+      clearTimeout(this.scrollAnimationTimeout);
+      this.scrollAnimationTimeout = undefined;
+    }
+    // Cancel any in-flight fetch requests
+    this.fetchAbortController?.abort();
+    this.fetchAbortController = undefined;
+    // Remove scroll event listeners
+    if (this.lyricsContainer) {
+      this.lyricsContainer.removeEventListener(
+        'wheel',
+        this._boundHandleUserScroll,
+      );
+      this.lyricsContainer.removeEventListener(
+        'touchmove',
+        this._boundHandleUserScroll,
+      );
     }
   }
 
   private async fetchLyrics() {
+    // Cancel any in-flight fetch to prevent stale results from racing
+    this.fetchAbortController?.abort();
+    const controller = new AbortController();
+    this.fetchAbortController = controller;
+
     this.isLoading = true;
     this.lyrics = undefined;
     this.lyricsSource = null;
@@ -1521,6 +1580,8 @@ export class AmLyrics extends LitElement {
     this.hasFetchedAllProviders = false;
     try {
       const resolvedMetadata = await this.resolveSongMetadata();
+      // If a newer fetch was triggered while we awaited, bail out
+      if (controller.signal.aborted) return;
 
       const isMusicIdOnlyRequest =
         Boolean(this.musicId) &&
@@ -1605,7 +1666,10 @@ export class AmLyrics extends LitElement {
       this.lyrics = undefined;
       this.lyricsSource = null;
     } finally {
-      this.isLoading = false;
+      // Only update loading state if this fetch wasn't superseded
+      if (!controller.signal.aborted) {
+        this.isLoading = false;
+      }
     }
   }
 
@@ -1932,7 +1996,7 @@ export class AmLyrics extends LitElement {
 
       try {
         // eslint-disable-next-line no-await-in-loop
-        const response = await fetch(url);
+        const response = await fetchWithTimeout(url);
         if (response.ok) {
           // eslint-disable-next-line no-await-in-loop
           const payload = await response.json();
@@ -2036,13 +2100,13 @@ export class AmLyrics extends LitElement {
       }
 
       const cacheUrl = `https://lyrics-api.binimum.org/?${cacheParams.toString()}`;
-      const cacheRes = await fetch(cacheUrl);
+      const cacheRes = await fetchWithTimeout(cacheUrl);
       if (cacheRes.ok) {
         const cacheData = await cacheRes.json();
         if (cacheData.results && cacheData.results.length > 0) {
           const result = cacheData.results[0];
           if (result.timing_type === 'word' && result.lyricsUrl) {
-            const ttmlRes = await fetch(result.lyricsUrl);
+            const ttmlRes = await fetchWithTimeout(result.lyricsUrl);
             if (ttmlRes.ok) {
               const ttmlText = await ttmlRes.text();
               const lines = AmLyrics.parseTTML(ttmlText);
@@ -2056,7 +2120,7 @@ export class AmLyrics extends LitElement {
             const fallbackParams = new URLSearchParams(params);
             const fallbackUrl = `https://lyricsplus.binimum.org/v2/lyrics/get?${fallbackParams.toString()}`;
             try {
-              const fallbackRes = await fetch(fallbackUrl);
+              const fallbackRes = await fetchWithTimeout(fallbackUrl);
               if (fallbackRes.ok) {
                 const payload = await fallbackRes.json();
                 const lines = AmLyrics.convertKPoeLyrics(payload);
@@ -2081,7 +2145,7 @@ export class AmLyrics extends LitElement {
 
             // If fallback fails or has no word sync, fall back to bini lyrics
             if (result.lyricsUrl) {
-              const ttmlRes = await fetch(result.lyricsUrl);
+              const ttmlRes = await fetchWithTimeout(result.lyricsUrl);
               if (ttmlRes.ok) {
                 const ttmlText = await ttmlRes.text();
                 const lines = AmLyrics.parseTTML(ttmlText);
@@ -2103,10 +2167,10 @@ export class AmLyrics extends LitElement {
     }
 
     // Shuffle servers so we pick a random one first, with all others as fallback
-    // Limit to 2 servers to prevent unnecessary API spam when Apple lyrics are missing
+    // Try up to 3 servers to improve reliability when some have CORS or connectivity issues
     const shuffledServers = [...KPOE_SERVERS]
       .sort(() => Math.random() - 0.5)
-      .slice(0, 2);
+      .slice(0, 3);
 
     for (const base of shuffledServers) {
       const normalizedBase = base.endsWith('/') ? base.slice(0, -1) : base;
@@ -2116,12 +2180,12 @@ export class AmLyrics extends LitElement {
 
       try {
         // eslint-disable-next-line no-await-in-loop
-        const response = await fetch(url);
+        const response = await fetchWithTimeout(url);
         if (response.ok) {
           // eslint-disable-next-line no-await-in-loop
           payload = await response.json();
         }
-      } catch (error) {
+      } catch {
         payload = null;
       }
 
@@ -2156,7 +2220,7 @@ export class AmLyrics extends LitElement {
       try {
         const fallbackParams = new URLSearchParams(params);
         const url = `https://lyricsplus.binimum.org/v2/lyrics/get?${fallbackParams.toString()}`;
-        const response = await fetch(url);
+        const response = await fetchWithTimeout(url);
         if (response.ok) {
           const payload = await response.json();
           if (payload) {
@@ -2198,7 +2262,6 @@ export class AmLyrics extends LitElement {
       if (!match) {
         // Skip non-timestamped lines (headers like [ti:], [ar:], etc.)
         // eslint-disable-next-line no-continue
-        // eslint-disable-next-line no-continue
         continue;
       }
       const minutes = parseInt(match[1], 10);
@@ -2221,7 +2284,6 @@ export class AmLyrics extends LitElement {
 
       // Skip empty lines (instrumental gaps)
       if (!text.trim()) {
-        // eslint-disable-next-line no-continue
         // eslint-disable-next-line no-continue
         continue;
       }
@@ -2261,9 +2323,9 @@ export class AmLyrics extends LitElement {
 
     if (!title || !artist) return null;
 
-    // Pick 2 random unique servers
+    // Pick 3 random unique servers for better reliability
     const shuffled = [...TIDAL_SERVERS].sort(() => Math.random() - 0.5);
-    const serversToTry = shuffled.slice(0, 2);
+    const serversToTry = shuffled.slice(0, 3);
 
     for (const base of serversToTry) {
       try {
@@ -2273,12 +2335,11 @@ export class AmLyrics extends LitElement {
         const searchQuery = `${title} ${artist}`;
         const searchParams = new URLSearchParams({ s: searchQuery });
         // eslint-disable-next-line no-await-in-loop
-        const searchResponse = await fetch(
+        const searchResponse = await fetchWithTimeout(
           `${normalizedBase}/search/?${searchParams.toString()}`,
         );
 
         if (!searchResponse.ok) {
-          // eslint-disable-next-line no-continue
           // eslint-disable-next-line no-continue
           continue;
         }
@@ -2288,7 +2349,6 @@ export class AmLyrics extends LitElement {
         const items = searchData?.data?.items;
 
         if (!Array.isArray(items) || items.length === 0) {
-          // eslint-disable-next-line no-continue
           // eslint-disable-next-line no-continue
           continue;
         }
@@ -2308,18 +2368,16 @@ export class AmLyrics extends LitElement {
         const trackId = bestTrack?.id;
         if (!trackId) {
           // eslint-disable-next-line no-continue
-          // eslint-disable-next-line no-continue
           continue;
         }
 
         // Step 2: Fetch lyrics
         // eslint-disable-next-line no-await-in-loop
-        const lyricsResponse = await fetch(
+        const lyricsResponse = await fetchWithTimeout(
           `${normalizedBase}/lyrics/?id=${trackId}`,
         );
 
         if (!lyricsResponse.ok) {
-          // eslint-disable-next-line no-continue
           // eslint-disable-next-line no-continue
           continue;
         }
@@ -2361,7 +2419,7 @@ export class AmLyrics extends LitElement {
     try {
       const searchQuery = `${artist} ${title}`;
       const params = new URLSearchParams({ q: searchQuery });
-      const response = await fetch(
+      const response = await fetchWithTimeout(
         `https://lrclib.net/api/search?${params.toString()}`,
         {
           headers: {
@@ -2433,7 +2491,9 @@ export class AmLyrics extends LitElement {
 
     try {
       const params = new URLSearchParams({ title, artist });
-      const response = await fetch(`${GENIUS_WORKER_URL}?${params.toString()}`);
+      const response = await fetchWithTimeout(
+        `${GENIUS_WORKER_URL}?${params.toString()}`,
+      );
 
       if (!response.ok) return null;
       const data = await response.json();
@@ -2467,8 +2527,7 @@ export class AmLyrics extends LitElement {
         }
       }
     } catch {
-      // eslint-disable-next-line no-console
-      console.error('No Genius lyrics found');
+      // Genius fetch failed, will fall through to return null
     }
 
     return null;
@@ -2889,12 +2948,12 @@ export class AmLyrics extends LitElement {
     if (this.lyricsContainer) {
       this.lyricsContainer.addEventListener(
         'wheel',
-        this.handleUserScroll.bind(this),
+        this._boundHandleUserScroll,
         { passive: true },
       );
       this.lyricsContainer.addEventListener(
         'touchmove',
-        this.handleUserScroll.bind(this),
+        this._boundHandleUserScroll,
         { passive: true },
       );
     }
@@ -3641,8 +3700,9 @@ export class AmLyrics extends LitElement {
     this.animatingLines = [];
 
     // Find the clicked line element and scroll to it with forceScroll (like YouLyPlus)
+    // Timestamps are already in milliseconds — match the data-start-time attribute directly
     const clickedLineElement = this.lyricsContainer?.querySelector(
-      `.lyrics-line[data-start-time="${line.timestamp * 1000}"]`,
+      `.lyrics-line[data-start-time="${line.text[0]?.timestamp || 0}"]`,
     ) as HTMLElement | null;
 
     if (clickedLineElement && this.lyricsContainer) {
@@ -4434,9 +4494,7 @@ export class AmLyrics extends LitElement {
     }
 
     if (running) {
-      this.animationFrameId = requestAnimationFrame(
-        this.animateProgress.bind(this),
-      );
+      this.animationFrameId = requestAnimationFrame(this._boundAnimateProgress);
     } else if (this.animationFrameId) {
       // Stop animation if no words are running
       cancelAnimationFrame(this.animationFrameId);

--- a/src/GoogleService.ts
+++ b/src/GoogleService.ts
@@ -5,8 +5,15 @@ const CONFIG = {
   GOOGLE: {
     MAX_RETRIES: 3,
     RETRY_DELAY_MS: 1000,
+    FETCH_TIMEOUT_MS: 6000,
   },
 };
+
+interface RomanizableLine {
+  text?: { text: string; romanizedText?: string }[] | string;
+  romanizedText?: string;
+  isWordSynced?: boolean;
+}
 
 /**
  * Service for translating and romanizing text using Google Translate (unofficial API)
@@ -16,6 +23,17 @@ export class GoogleService {
     return new Promise(resolve => {
       setTimeout(resolve, ms);
     });
+  }
+
+  private static fetchWithTimeout(
+    url: string,
+    timeoutMs = CONFIG.GOOGLE.FETCH_TIMEOUT_MS,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    return fetch(url, { signal: controller.signal }).finally(() =>
+      clearTimeout(timeoutId),
+    );
   }
 
   private static isPurelyLatinScript(text: string): boolean {
@@ -77,7 +95,7 @@ export class GoogleService {
         try {
           const url = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=${targetLang}&dt=t&q=${encodeURIComponent(joinedText)}`;
           // eslint-disable-next-line no-await-in-loop
-          const response = await fetch(url);
+          const response = await GoogleService.fetchWithTimeout(url);
           if (!response.ok) throw new Error(`Status ${response.status}`);
           // eslint-disable-next-line no-await-in-loop
           const data = await response.json();
@@ -158,18 +176,22 @@ export class GoogleService {
     return isArray ? finalArray : finalArray[0];
   }
 
-  static async romanize(originalLyrics: any): Promise<any> {
+  static async romanize<T extends RomanizableLine>(
+    originalLyrics: T[] | { data?: T[]; content?: T[] },
+  ): Promise<T[]> {
     // Determine if we should treat as word-synced (has syllabus) or line-synced
-
-    const lines = Array.isArray(originalLyrics)
+    const lines: T[] = Array.isArray(originalLyrics)
       ? originalLyrics
-      : originalLyrics.data || originalLyrics.content;
+      : (originalLyrics as { data?: T[]; content?: T[] }).data ||
+        (originalLyrics as { data?: T[]; content?: T[] }).content ||
+        [];
 
-    if (!lines) return originalLyrics;
+    if (!lines || lines.length === 0)
+      return Array.isArray(originalLyrics) ? originalLyrics : [];
 
     // Check if word synced
     const isWordSynced = lines.some(
-      (l: any) =>
+      (l: RomanizableLine) =>
         l.isWordSynced !== false && Array.isArray(l.text) && l.text.length > 1,
     );
 
@@ -180,9 +202,11 @@ export class GoogleService {
     return this.romanizeLineSynced(lines);
   }
 
-  static async romanizeWordSynced(lines: any[]): Promise<any[]> {
+  static async romanizeWordSynced<T extends RomanizableLine>(
+    lines: T[],
+  ): Promise<T[]> {
     return Promise.all(
-      lines.map(async (line: any) => {
+      lines.map(async (line: T) => {
         if (
           !line.text ||
           !Array.isArray(line.text) ||
@@ -192,15 +216,19 @@ export class GoogleService {
           return line;
 
         // Get the entire line text to romanize together for context-aware pronunciation
-        const fullText = line.text.map((s: any) => s.text).join('');
+        const fullText = line.text
+          .map((s: { text: string }) => s.text)
+          .join('');
 
         // romanizeTexts expects an array of strings, so we pass an array of one
         const [romanizedFullLine] = await this.romanizeTexts([fullText]);
 
-        const newSyllabus = line.text.map((s: any) => ({
-          ...s,
-          romanizedText: s.romanizedText, // Keep any existing syllabus romanization if provided by API natively
-        }));
+        const newSyllabus = line.text.map(
+          (s: { text: string; romanizedText?: string }) => ({
+            ...s,
+            romanizedText: s.romanizedText, // Keep any existing syllabus romanization if provided by API natively
+          }),
+        );
 
         return {
           ...line,
@@ -211,22 +239,24 @@ export class GoogleService {
     );
   }
 
-  static async romanizeLineSynced(lines: any[]): Promise<any[]> {
-    const linesToRomanize = lines.map((line: any) => {
+  static async romanizeLineSynced<T extends RomanizableLine>(
+    lines: T[],
+  ): Promise<T[]> {
+    const linesToRomanize = lines.map((line: T) => {
       // If already romanized, skip
       if (line.romanizedText) {
         return '';
       }
       // If it's line-synced, it usually has 1 syllable with the full text.
       if (Array.isArray(line.text) && line.text.length > 0) {
-        return line.text.map((s: any) => s.text).join('');
+        return line.text.map((s: { text: string }) => s.text).join('');
       }
       return '';
     });
 
     const romanizedLines = await this.romanizeTexts(linesToRomanize);
 
-    return lines.map((line: any, index: number) => ({
+    return lines.map((line: T, index: number) => ({
       ...line,
       romanizedText: romanizedLines[index] || '',
     }));
@@ -255,7 +285,7 @@ export class GoogleService {
             const romanizeUrl = `https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=en&dt=rm&q=${encodeURIComponent(
               text,
             )}`;
-            const response = await fetch(romanizeUrl);
+            const response = await GoogleService.fetchWithTimeout(romanizeUrl);
             const data = await response.json();
 
             // Response format is [[["...","...","...","romanization"]],...]


### PR DESCRIPTION
- Add fetch timeouts (8s) to all lyrics requests to prevent indefinite hangs from CORS or unresponsive servers (fixes #12)
- Add AbortController to cancel stale fetches on rapid song changes
- Increase server retry count from 2 to 3 for KPOE and Tidal
- Fix handleLineClick selector using wrong timestamp unit (ms * 1000)
- Fix memory leaks: clear all timeouts in disconnectedCallback
- Fix event listener leak: use stored bound references for proper removal
- Use stored bound ref for animateProgress to avoid allocation per frame
- Remove duplicate eslint-disable comments
- Replace any types with generics in GoogleService romanize methods
- Add fetch timeouts to GoogleService translate/romanize requests